### PR TITLE
fix function name for spendTapjoyCurrency

### DIFF
--- a/src/useTapjoy.js
+++ b/src/useTapjoy.js
@@ -33,7 +33,7 @@ export const useTapjoy = options => {
   }, []);
 
   const spendTapjoyCurrency = useCallback((amount: number) => {
-    return tapjoy.current.spendCurrencyAction(amount);
+    return tapjoy.current.spendCurrency(amount);
   }, []);
 
   const setTapjoyUserId = useCallback((userID: number) => {


### PR DESCRIPTION
Fixed bug, when I call spendTapjoyCurrency hook, I get error 
TypeError: tapjoy.current.spendCurrencyAction is not a function
I found a mistake, after changing the name error was fixed and the hook works fine.