### PR TITLE
Fix the build for RN 0.63+

### DIFF
--- a/RNTapjoy.podspec
+++ b/RNTapjoy.podspec
@@ -38,11 +38,4 @@ Pod::Spec.new do |s|
     ss.source_files = "ios/RN/**/*.{h,m}"
   end
 
-  s.xcconfig = {
-    'HEADER_SEARCH_PATHS' => [
-        "$(inherited)",
-        "${SRCROOT}/../../React/**",
-        "${SRCROOT}/../../node_modules/react-native/**"
-      ].join(' ')
-  }
 end

--- a/ios/TapjoyModule.h
+++ b/ios/TapjoyModule.h
@@ -16,7 +16,6 @@
 #import <Tapjoy/TJPlacement.h>
 #import <React/RCTLog.h>
 #import "TapjoyPlacementListener.h"
-#import "AppDelegate.h"
 
 @interface TapjoyModule : RCTEventEmitter <RCTBridgeModule> {
   RCTPromiseResolveBlock mResolve;
@@ -27,7 +26,7 @@
   Boolean listening;
 }
 
-@property (nonatomic, retain) AppDelegate *viewController;
+@property (nonatomic, retain) UIViewController *viewController;
 
 - (void) sendJSEvent:(NSString *)title props:(NSDictionary *)props;
 


### PR DESCRIPTION
The current version of RNTapJoy has build problems on iOS - header search paths are incorrectly overwritten. This PR fixes that.