### PR TITLE
tapjoy sdk version upgrade(12.9.1)

### DIFF
--- a/RNTapjoy.podspec
+++ b/RNTapjoy.podspec
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
 
   s.platform     = :ios, "9.0"
   s.dependency 'React'
-  s.dependency 'TapjoySDK', '12.4.2'
+  s.dependency 'TapjoySDK', '12.9.1'
 
   s.subspec "RCT" do |ss|
     ss.source_files = "ios/RCT/**/*.{h,m}"


### PR DESCRIPTION
tapjoy sdk version upgrade(12.9.1)

In the new version **12.10.0**, the setUserId method has been removed, making it difficult to use.

https://dev.tapjoy.com/en/ios-sdk/Changelog